### PR TITLE
Fix for Arch Linux logo and add Arch Linux to README as working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ _Note:_ These are only the ones that have actually been tested (so far). screenf
 
 - [x] OS X
 - [x] Windows (requires Cygwin)
+- [x] Arch Linux
 - [x] Fedora
 - [x] Linux Mint
 - [x] LMDE

--- a/src/screenfetch-c.h
+++ b/src/screenfetch-c.h
@@ -153,8 +153,8 @@ char* oldarch_logo[] =
 /* 18 */
 char* arch_logo[] =
 {
-	""TLCY"                   -`",
-	""TLCY"                  .o+`                 " TNRM,
+	""TLCY"                   -`                 ",
+	""TLCY"                  .o+`                " TNRM,
 	""TLCY"                 `ooo/                " TNRM,
 	""TLCY"                `+oooo:               " TNRM,
 	""TLCY"               `+oooooo:              " TNRM,


### PR DESCRIPTION
Spacing issues in the Arch Linux logo. Also, I've added Arch Linux as checked to the README because it's fully working without any modifications from me now. Will test on FreeBSD soon.
