### PR TITLE
some changes

### DIFF
--- a/src/colors.h
+++ b/src/colors.h
@@ -10,14 +10,14 @@
 #define SCREENFETCH_C_COLORS_H
 
 #define TNRM "\x1B[0m" /* normal */
-#define TBLK "\x1B[30m" /* black */
-#define TRED "\x1B[31m" /* red */
-#define TGRN "\x1B[32m" /* green */
-#define TBRN "\x1B[33m" /* brown */
-#define TBLU "\x1B[34m" /* blue */
-#define TPUR "\x1B[35m" /* purple */
-#define TCYN "\x1B[36m" /* cyan */
-#define TLGY "\x1B[37m" /* light gray */
+#define TBLK "\x1B[0;30m" /* black */
+#define TRED "\x1B[0;31m" /* red */
+#define TGRN "\x1B[0;32m" /* green */
+#define TBRN "\x1B[0;33m" /* brown */
+#define TBLU "\x1B[0;34m" /* blue */
+#define TPUR "\x1B[0;35m" /* purple */
+#define TCYN "\x1B[0;36m" /* cyan */
+#define TLGY "\x1B[0;37m" /* light gray */
 #define TDGY "\x1B[1;30m" /* dark gray */
 #define TLRD "\x1B[1;31m" /* light red */
 #define TLGN "\x1B[1;32m" /* light green */

--- a/src/detect.h
+++ b/src/detect.h
@@ -9,9 +9,9 @@
 #ifndef SCREENFETCH_C_DETECT_H
 #define SCREENFETCH_C_DETECT_H
 
-void detect_distro(char *str);
-void detect_arch(char *str);
-void detect_host(char *str);
+void detect_distro(char *str1, char *str2);
+/*void detect_arch(char *str);*/
+void detect_host(char *str1, char *str2);
 void detect_kernel(char *str);
 void detect_uptime(char *str);
 void detect_pkgs(char *str, const char *distro_str);
@@ -24,6 +24,6 @@ void detect_res(char *str);
 void detect_de(char *str);
 void detect_wm(char *str);
 void detect_wm_theme(char *str, const char *wm_str);
-void detect_gtk(char *str);
+void detect_gtk(char *str1, char *str2, char *str3);
 
 #endif /* SCREENFETCH_C_DETECT_H */

--- a/src/disp.c
+++ b/src/disp.c
@@ -65,295 +65,206 @@ void display_verbose(char *data[], char *data_names[])
 	return;
 }
 
+
+void process_logo_only(char *distro[], unsigned short int num)
+{
+	unsigned short int x = 0;
+
+	for (x = 0; x < num; x++)
+		printf("%s\n", distro[x]);
+
+	return;
+}
+
 /*	output_logo_only
 	outputs an ASCII logo based upon the distro name passed to it
 	argument char *distro the name of the distro to output
 */
 void output_logo_only(char *distro)
 {
-	int i = 0;
-
 	if (STREQ(distro, "Windows"))
 	{
-		for (i = 0; i < 16; i++)
-		{
-			printf("%s\n", windows_logo[i]);
-		}
+		process_logo_only(windows_logo, 16);
 	}
 	else if (strstr(distro, "OS X"))
 	{
-		for (i = 0; i < 16; i++)
-		{
-			printf("%s\n", macosx_logo[i]);
-		}
+		process_logo_only(macosx_logo, 16);
 	}
 	else if (STREQ(distro, "Arch Linux - Old"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", oldarch_logo[i]);
-		}
+		process_logo_only(oldarch_logo, 18);
 	}
 	else if (STREQ(distro, "Arch Linux"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", arch_logo[i]);
-		}
+		process_logo_only(arch_logo, 19);
 	}
 	else if (STREQ(distro, "LinuxMint"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", mint_logo[i]);
-		}
+		process_logo_only(mint_logo, 18);
 	}
 	else if (STREQ(distro, "LMDE"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", lmde_logo[i]);
-		}
+		process_logo_only(lmde_logo, 18);
 	}
 	else if (STREQ(distro, "Ubuntu") || STREQ(distro, "Lubuntu")
 			|| STREQ(distro, "Xubuntu"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", ubuntu_logo[i]);
-		}
+		process_logo_only(ubuntu_logo, 18);
 	}
 	else if (STREQ(distro, "Debian"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", debian_logo[i]);
-		}
+		process_logo_only(debian_logo, 18);
 	}
 	else if (STREQ(distro, "CrunchBang"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", crunchbang_logo[i]);
-		}
+		process_logo_only(crunchbang_logo, 18);
 	}
 	else if (STREQ(distro, "Gentoo"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", gentoo_logo[i]);
-		}
+		process_logo_only(gentoo_logo, 18);
 	}
 	else if (STREQ(distro, "Funtoo"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", funtoo_logo[i]);
-		}
+		process_logo_only(funtoo_logo, 18);
 	}
 	else if (STREQ(distro, "Fedora"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", fedora_logo[i]);
-		}
+		process_logo_only(fedora_logo, 18);
 	}
 	else if (STREQ(distro, "Mandriva") || STREQ(distro, "Mandrake"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", mandriva_mandrake_logo[i]);
-		}
+		process_logo_only(mandriva_mandrake_logo, 18);
 	}
 	else if (STREQ(distro, "OpenSUSE"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", opensuse_logo[i]);
-		}
+		process_logo_only(opensuse_logo, 18);
 	}
 	else if (STREQ(distro, "Slackware"))
 	{
-		for (i = 0; i < 21; i++)
-		{
-			printf("%s\n", slackware_logo[i]);
-		}
+		process_logo_only(slackware_logo, 21);
 	}
 	else if (STREQ(distro, "Red Hat Linux"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", redhat_logo[i]);
-		}
+		process_logo_only(redhat_logo, 18);
 	}
 	else if (STREQ(distro, "Frugalware"))
 	{
-		for (i = 0; i < 23; i++)
-		{
-			printf("%s\n", frugalware_logo[i]);
-		}
+		process_logo_only(frugalware_logo, 23);
 	}
 	else if (STREQ(distro, "Peppermint"))
 	{
-		for (i = 0; i < 19; i++)
-		{
-			printf("%s\n", peppermint_logo[i]);
-		}
+		process_logo_only(peppermint_logo, 19);
 	}
 	else if (STREQ(distro, "SolusOS"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", solusos_logo[i]);
-		}
+		process_logo_only(solusos_logo, 18);
 	}
 	else if (STREQ(distro, "Mageia"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", mageia_logo[i]);
-		}
+		process_logo_only(mageia_logo, 18);
 	}
 	else if (STREQ(distro, "ParabolaGNU/Linux-libre"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", parabolagnu_linuxlibre_logo[i]);
-		}
+		process_logo_only(parabolagnu_linuxlibre_logo, 18);
 	}
 	else if (STREQ(distro, "Viperr"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", viperr_logo[i]);
-		}
+		process_logo_only(viperr_logo, 18);
 	}
 	else if (STREQ(distro, "LinuxDeepin"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", linuxdeepin_logo[i]);
-		}
+		process_logo_only(linuxdeepin_logo, 18);
 	}
 	else if (STREQ(distro, "Chakra"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", chakra_logo[i]);
-		}
+		process_logo_only(chakra_logo, 18);
 	}
 	else if (STREQ(distro, "Fuduntu"))
 	{
-		for (i = 0; i < 21; i++)
-		{
-			printf("%s\n", fuduntu_logo[i]);
-		}
+		process_logo_only(fuduntu_logo, 21);
 	}
 	else if (STREQ(distro, "Trisquel"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", trisquel_logo[i]);
-		}
+		process_logo_only(trisquel_logo, 18);
 	}
 	else if (STREQ(distro, "Manjaro"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", manjaro_logo[i]);
-		}
+		process_logo_only(manjaro_logo, 18);
 	}
 	else if (STREQ(distro, "elementary OS"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", elementaryos_logo[i]);
-		}
+		process_logo_only(elementaryos_logo, 18);
 	}
 	else if (STREQ(distro, "Scientific Linux"))
 	{
-		for (i = 0; i < 20; i++)
-		{
-			printf("%s\n", scientificlinux_logo[i]);
-		}
+		process_logo_only(scientificlinux_logo, 20);
 	}
 	else if (STREQ(distro, "Backtrack Linux"))
 	{
-		for (i = 0; i < 21; i++)
-		{
-			printf("%s\n", backtracklinux_logo[i]);
-		}
+		process_logo_only(backtracklinux_logo, 21);
 	}
 	else if (STREQ(distro, "Kali Linux"))
 	{
-		for (i = 0; i < 21; i++)
-		{
-			printf("%s\n", kalilinux_logo[i]);
-		}
+		process_logo_only(kalilinux_logo, 21);
 	}
 	else if (STREQ(distro, "Sabayon"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", sabayon_logo[i]);
-		}
+		process_logo_only(sabayon_logo, 18);
 	}
 	else if (STREQ(distro, "FreeBSD"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", freebsd_logo[i]);
-		}
+		process_logo_only(freebsd_logo, 18);
 	}
 	else if (STREQ(distro, "OpenBSD"))
 	{
-		for (i = 0; i < 23; i++)
-		{
-			printf("%s\n", openbsd_logo[i]);
-		}
+		process_logo_only(openbsd_logo, 23);
 	}
 	else if (STREQ(distro, "NetBSD"))
 	{
-		for (i = 0; i < 20; i++)
-		{
-			printf("%s\n", netbsd_logo[i]);
-		}
+		process_logo_only(netbsd_logo, 20);
 	}
 	else if (STREQ(distro, "DragonFly BSD"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			printf("%s\n", dragonflybsd_logo[i]);
-		}
+		process_logo_only(dragonflybsd_logo, 18);
 	}
 	else if (STREQ(distro, "Android"))
 	{
-		for (i = 0; i < 16; i++)
-		{
-			printf("%s\n", android_logo[i]);
-		}
+		process_logo_only(android_logo, 16);
 	}
 	else if (STREQ(distro, "Solaris"))
 	{
-		for (i = 0; i < 17; i++)
-		{
-			printf("%s\n", solaris_logo[i]);
-		}
+		process_logo_only(solaris_logo, 17);
 	}
 	else if (STREQ(distro, "Angstrom"))
 	{
-		for (i = 0; i < 16; i++)
-		{
-			printf("%s\n", angstrom_logo[i]);
-		}
+		process_logo_only(angstrom_logo, 16);
 	}
 	else /* if (STREQ(distro_str, "Linux")) */
 	{
-		for (i = 0; i < 16; i++)
-		{
-			printf("%s\n", linux_logo[i]);
-		}
+		process_logo_only(linux_logo, 16);
 	}
+
+	return;
+}
+
+/* process_data
+   handle the detected distro arguments
+*/
+void process_data(char *data[], char *data_names[], char *logo[], unsigned short int num1, unsigned short int num2, char *col1, char *col2, char *col3)
+{
+	unsigned short int x = 0;
+
+	if (0 == num2)
+		for (x = 0; x < num1; x++)
+			printf("%s %s%s%s%s%s%s\n", logo[x], col1, col2, col3,
+				data_names[x], TNRM, data[x]);
+	else
+		for (x = 0; x < num1; x++)
+			if (x < num2)
+				printf("%s %s%s%s%s%s%s\n", logo[x], col1, col2, col3,
+                    data_names[x], TNRM, data[x]);
+			else
+				printf("%s\n", logo[x]);
 
 	return;
 }
@@ -364,434 +275,166 @@ void output_logo_only(char *distro)
 */
 void main_ascii_output(char *data[], char *data_names[])
 {
-	int i = 0;
-
 	if (strstr(data[1], "Microsoft"))
 	{
-		for (i = 0; i < 16; i++)
-		{
-			printf("%s " TRED "%s" TWHT "%s" TNRM "\n", windows_logo[i],
-					data_names[i], data[i]);
-		}
+		process_data(data, data_names, windows_logo, 16, 0, TRED, TWHT, TRED);
 	}
 	else if (strstr(data[1], "OS X"))
 	{
-		for (i = 0; i < 16; i++)
-		{
-			printf("%s " TLBL "%s" TNRM "%s\n", macosx_logo[i], data_names[i],
-					data[i]);
-		}
+		process_data(data, data_names, macosx_logo, 16, 0, TLBL, TNRM, TLBL);
 	}
 	else if (STREQ(data[1], "Arch Linux - Old"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLBL "%s" TNRM "%s" TNRM "\n", oldarch_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", oldarch_logo[i]);
-		}
+		process_data(data, data_names, oldarch_logo, 18, 16, TLBL, TNRM, TLBL);
 	}
 	else if (STREQ(data[1], "Arch Linux"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLCY "%s" TNRM "%s" TNRM "\n", arch_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", arch_logo[i]);
-		}
+		process_data(data, data_names, arch_logo, 19, 17, TLCY, TNRM, TLCY);
 	}
 	else if (STREQ(data[1], "LinuxMint"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGN "%s" TNRM "%s" TNRM "\n", mint_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", mint_logo[i]);
-		}
+		process_data(data, data_names, mint_logo, 18, 16, TLGN, TNRM, TLGN);
 	}
 	else if (STREQ(data[1], "LMDE"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGN "%s" TNRM "%s\n", lmde_logo[i], data_names[i],
-						data[i]);
-			else
-				printf("%s\n", lmde_logo[i]);
-		}
+		process_data(data, data_names, lmde_logo, 18, 16, TLGN, TNRM, TLGN);
 	}
 	else if (STREQ(data[1], "Ubuntu") || STREQ(data[1], "Lubuntu")
 			|| STREQ(data[1], "Xubuntu"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLRD "%s" TNRM "%s" TNRM "\n", ubuntu_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", ubuntu_logo[i]);
-		}
+		process_data(data, data_names, ubuntu_logo, 18, 16, TLRD, TNRM, TLRD);
 	}
 	else if (STREQ(data[1], "Debian"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLRD "%s" TNRM "%s\n", debian_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", debian_logo[i]);
-		}
+		process_data(data, data_names, debian_logo, 18, 16, TLRD, TNRM, TLRD);
 	}
 	else if (STREQ(data[1], "CrunchBang"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TDGY "%s" TNRM "%s\n", crunchbang_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", crunchbang_logo[i]);
-		}
+		process_data(data, data_names, crunchbang_logo, 18, 16, TDGY, TNRM, TDGY);
 	}
 	else if (STREQ(data[1], "Gentoo"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLPR "%s" TNRM "%s\n", gentoo_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", gentoo_logo[i]);
-		}
+		process_data(data, data_names, gentoo_logo, 18, 16, TLPR, TNRM, TLPR);
 	}
 	else if (STREQ(data[1], "Funtoo"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLPR "%s" TNRM "%s\n", funtoo_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", funtoo_logo[i]);
-		}
+		process_data(data, data_names, funtoo_logo, 18, 16, TLPR, TNRM, TLPR);
 	}
 	else if (STREQ(data[1], "Fedora"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLBL "%s" TNRM "%s\n", fedora_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", fedora_logo[i]);
-		}
+		process_data(data, data_names, fedora_logo, 18, 16, TLBL, TNRM, TLBL);
 	}
 	else if (STREQ(data[1], "Mandriva") || STREQ(data[1], "Mandrake"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLBL "%s" TNRM "%s\n", mandriva_mandrake_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", mandriva_mandrake_logo[i]);
-		}
+		process_data(data, data_names, mandriva_mandrake_logo, 18, 16, TLBL, TNRM, TLBL);
 	}
 	else if (STREQ(data[1], "OpenSUSE"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGN "%s" TNRM "%s\n", opensuse_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", opensuse_logo[i]);
-		}
+		process_data(data, data_names, opensuse_logo, 18, 16, TLGN, TNRM, TLGN);
 	}
 	else if (STREQ(data[1], "Slackware"))
 	{
-		for (i = 0; i < 21; i++)
-		{
-			if (i < 16)
-				printf("%s " TLBL "%s" TNRM "%s\n", slackware_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", slackware_logo[i]);
-		}
+		process_data(data, data_names, slackware_logo, 21, 16, TLBL, TNRM, TLBL);
 	}
 	else if (STREQ(data[1], "Red Hat Linux"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TRED "%s" TNRM "%s\n", redhat_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", redhat_logo[i]);
-		}
+		process_data(data, data_names, redhat_logo, 18, 16, TRED, TNRM, TRED);
 	}
 	else if (STREQ(data[1], "Frugalware"))
 	{
-		for (i = 0; i < 23; i++)
-		{
-			if (i < 16)
-				printf("%s " TLCY "%s" TNRM "%s\n", frugalware_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", frugalware_logo[i]);
-		}
+		process_data(data, data_names, frugalware_logo, 23, 16, TLCY, TNRM, TLCY);
 	}
 	else if (STREQ(data[1], "Peppermint"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLRD "%s" TNRM "%s\n", peppermint_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", peppermint_logo[i]);
-		}
+		process_data(data, data_names, peppermint_logo, 18, 16, TLRD, TNRM, TLRD);
 	}
 	else if (STREQ(data[1], "SolusOS"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGY "%s" TNRM "%s\n", solusos_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", solusos_logo[i]);
-		}
+		process_data(data, data_names, solusos_logo, 18, 16, TLGY, TNRM, TLGY);
 	}
 	else if (STREQ(data[1], "Mageia"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGY "%s" TNRM "%s\n", mageia_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", mageia_logo[i]);
-		}
+		process_data(data, data_names, mageia_logo, 18, 16, TLGY, TNRM, TLGY);
 	}
 	else if (STREQ(data[1], "ParabolaGNU/Linux-libre"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGY "%s" TLPR "%s\n",
-					parabolagnu_linuxlibre_logo[i],	data_names[i], data[i]);
-			else
-				printf("%s\n", parabolagnu_linuxlibre_logo[i]);
-		}
+		process_data(data, data_names, parabolagnu_linuxlibre_logo, 18, 16, TLGY, TLPR, TLGY);
 	}
 	else if (STREQ(data[1], "Viperr"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGY "%s" TNRM "%s\n", viperr_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", viperr_logo[i]);
-		}
+		process_data(data, data_names, viperr_logo, 18, 16, TLGY, TNRM, TLGY);
 	}
 	else if (STREQ(data[1], "LinuxDeepin"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGN "%s" TNRM "%s\n", linuxdeepin_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", linuxdeepin_logo[i]);
-		}
+		process_data(data, data_names, linuxdeepin_logo, 18, 16, TLGN, TNRM, TLGN);
 	}
 	else if (STREQ(data[1], "Chakra"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLBL "%s" TNRM "%s\n", chakra_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", chakra_logo[i]);
-		}
+		process_data(data, data_names, chakra_logo, 18, 16, TLBL, TNRM, TLBL);
 	}
 	else if (STREQ(data[1], "Fuduntu"))
 	{
-		for (i = 0; i < 21; i++)
-		{
-			if (i < 16)
-				printf("%s " TLRD "%s" TNRM "%s\n", fuduntu_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", fuduntu_logo[i]);
-		}
+		process_data(data, data_names, fuduntu_logo, 21, 16, TLRD, TNRM, TLRD);
 	}
 	else if (STREQ(data[1], "Trisquel"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLBL "%s" TNRM "%s\n", trisquel_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", trisquel_logo[i]);
-		}
+		process_data(data, data_names, trisquel_logo, 18, 16, TLBL, TNRM, TLBL);
 	}
 	else if (STREQ(data[1], "Manjaro"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s %s%s\n", manjaro_logo[i], data_names[i], data[i]);
-			else
-				printf("%s\n", manjaro_logo[i]);
-		}
+		process_data(data, data_names, manjaro_logo, 18, 16, "", "", "");
 	}
 	else if (STREQ(data[1], "elementary OS"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGN "%s" TNRM "%s\n", elementaryos_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", elementaryos_logo[i]);
-		}
+		process_data(data, data_names, elementaryos_logo, 18, 16, TLGN, TNRM, TLGN);
 	}
 	else if (STREQ(data[1], "Scientific Linux"))
 	{
-		for (i = 0; i < 20; i++)
-		{
-			if (i < 16)
-				printf("%s " TLRD "%s" TNRM "%s\n", scientificlinux_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", scientificlinux_logo[i]);
-		}
+		process_data(data, data_names, scientificlinux_logo, 20, 16, TLRD, TNRM, TLRD);
 	}
 	else if (STREQ(data[1], "Backtrack Linux"))
 	{
-		for (i = 0; i < 21; i++)
-		{
-			if (i < 16)
-				printf("%s " TLRD "%s" TNRM "%s\n", backtracklinux_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", backtracklinux_logo[i]);
-		}
+		process_data(data, data_names, backtracklinux_logo, 21, 16, TLRD, TNRM, TLRD);
 	}
 	else if (STREQ(data[1], "Kali Linux"))
 	{
-		for (i = 0; i < 21; i++)
-		{
-			if (i < 16)
-				printf("%s " TLBL "%s" TNRM "%s\n", kalilinux_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", backtracklinux_logo[i]);
-		}
+		process_data(data, data_names, backtracklinux_logo, 21, 16, TLBL, TNRM, TLBL);
 	}
 	else if (STREQ(data[1], "Sabayon"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLBL "%s" TNRM "%s\n", sabayon_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", sabayon_logo[i]);
-		}
+		process_data(data, data_names, sabayon_logo, 18, 16, TLBL, TNRM, TLBL);
 	}
 	else if (STREQ(data[1], "Android"))
 	{
-		for (i = 0; i < 16; i++)
-		{
-			if (i < 12)
-				printf("%s " TLGN "%s" TNRM "%s\n", android_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", android_logo[i]);
-		}
+		process_data(data, data_names, android_logo, 16, 12, TLGN, TNRM, TLGN);
 	}
 	else if (STREQ(data[1], "Angstrom"))
 	{
-		for (i = 0; i < 16; i++)
-		{
-			printf("%s %s%s\n", angstrom_logo[i], data_names[i], data[i]);
-		}
+		process_data(data, data_names, angstrom_logo, 16, 0, "", "", "");
 	}
 	else if (STREQ(data[1], "Linux"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLGY "%s" TNRM "%s\n", linux_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", linux_logo[i]);
-		}
+		process_data(data, data_names, linux_logo, 18, 16, TLGY, TNRM, TLGY);
 	}
 	else if (STREQ(data[1], "FreeBSD"))
 	{
-		for (i = 0; i < 18; i++)
-		{
-			if (i < 16)
-				printf("%s " TLRD "%s" TNRM "%s\n", freebsd_logo[i],
-						data_names[i], data[i]);
-			else
-				printf("%s\n", freebsd_logo[i]);
-		}
+		process_data(data, data_names, freebsd_logo, 18, 16, TLRD, TNRM, TLRD);
 	}
 	else if (STREQ(data[1], "OpenBSD"))
 	{
-		for (i = 0; i < 23; i++)
-		{
-			if (i < 16)
-				printf("%s %s%s\n", openbsd_logo[i], data_names[i], data[i]);
-			else
-				printf("%s\n", openbsd_logo[i]);
-		}
+		process_data(data, data_names, openbsd_logo, 23, 16, "", "", "");
 	}
 	else if (STREQ(data[1], "NetBSD"))
 	{
-		for (i = 0; i < 23; i++)
-		{
-			if (i < 16)
-				printf("%s %s%s\n", netbsd_logo[i], data_names[i], data[i]);
-			else
-				printf("%s\n", netbsd_logo[i]);
-		}
+		process_data(data, data_names, netbsd_logo, 23, 16, "", "", "");
 	}
 	else if (STREQ(data[1], "DragonFly BSD"))
 	{
-		for (i = 0; i < 23; i++)
-		{
-			if (i < 16)
-				printf("%s %s%s\n", dragonflybsd_logo[i], data_names[i],
-						data[i]);
-			else
-				printf("%s\n", dragonflybsd_logo[i]);
-		}
+		process_data(data, data_names, dragonflybsd_logo, 23, 16, "", "", "");
 	}
 	else if (STREQ(data[1], "SunOS"))
 	{
-		for (i = 0; i < 17; i++)
-		{
-			if (i < 16)
-				printf("%s %s%s\n", solaris_logo[i], data_names[i], data[i]);
-			else
-				printf("%s\n", solaris_logo[i]);
-		}
+		process_data(data, data_names, solaris_logo, 17, 16, "", "", "");
 	}
 	else
 	{

--- a/src/disp.h
+++ b/src/disp.h
@@ -15,7 +15,9 @@
 void display_version(void);
 void display_help(void);
 void display_verbose(char *data[], char *data_names[]);
+void process_logo_only(char *distro[], unsigned short int num);
 void output_logo_only(char *distro);
+void process_data(char *data[], char *data_names[], char *logo[], unsigned short int num1, unsigned short int num2, char *col1, char *col2, char *col3);
 void main_ascii_output(char *data[], char *data_names[]);
 void main_text_output(char *data[], char *data_names[]);
 

--- a/src/logos.c
+++ b/src/logos.c
@@ -31,10 +31,10 @@ char *oldarch_logo[] =
 	"                                     " TNRM
 };
 
-/* 18 */
+/* 19 */
 char *arch_logo[] =
 {
-	""TLCY"                   -`                 ",
+	""TLCY"                   -`                 " TNRM,
 	""TLCY"                  .o+`                " TNRM,
 	""TLCY"                 `ooo/                " TNRM,
 	""TLCY"                `+oooo:               " TNRM,

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,7 @@ int main(int argc, char **argv)
 {
 	char given_distro_str[MAX_STRLEN] = "Unknown";
 	char distro_str[MAX_STRLEN] = "Unknown";
-	char arch_str[MAX_STRLEN] = "Unknown";
+	/*char arch_str[MAX_STRLEN] = "Unknown";*/
 	char host_str[MAX_STRLEN] = "Unknown";
 	char kernel_str[MAX_STRLEN] = "Unknown";
 	char uptime_str[MAX_STRLEN] = "Unknown";
@@ -48,13 +48,16 @@ int main(int argc, char **argv)
 	char wm_str[MAX_STRLEN] = "Unknown";
 	char wm_theme_str[MAX_STRLEN] = "Unknown";
 	char gtk_str[MAX_STRLEN] = "Unknown";
+	char icon_str[MAX_STRLEN] = "Unknown";
+	char font_str[MAX_STRLEN] = "Unknown";
 
-	char *detected_arr[16] =
+	char host_colour[10];
+
+	char *detected_arr[17] =
 	{
 		host_str,
 		distro_str,
 		kernel_str,
-		arch_str,
 		cpu_str,
 		gpu_str,
 		shell_str,
@@ -66,15 +69,16 @@ int main(int argc, char **argv)
 		de_str,
 		wm_str,
 		wm_theme_str,
-		gtk_str
+		gtk_str,
+		icon_str,
+		font_str
 	};
 
-	char *detected_arr_names[16] =
+	char *detected_arr_names[17] =
 	{
 		"",
 		"OS: ",
 		"Kernel: ",
-		"Arch: ",
 		"CPU: ",
 		"GPU: ",
 		"Shell: ",
@@ -86,7 +90,9 @@ int main(int argc, char **argv)
 		"DE: ",
 		"WM: ",
 		"WM Theme: ",
-		"GTK: "
+		"GTK: ",
+		"Icon Theme: ",
+		"Font: "
 	};
 
 	bool manual = false, logo = true, portrait = false;
@@ -162,11 +168,11 @@ int main(int argc, char **argv)
 
 			/* if the user specifies an asterisk, fill the data in for them */
 			if (STREQ(distro_str, "*"))
-				detect_distro(distro_str);
-			if (STREQ(arch_str, "*"))
-				detect_arch(arch_str);
+				detect_distro(distro_str, host_colour);
+			/*if (STREQ(arch_str, "*"))
+				detect_arch(arch_str);*/
 			if (STREQ(host_str, "*"))
-				detect_host(host_str);
+				detect_host(host_str, host_colour);
 			if (STREQ(kernel_str, "*"))
 				detect_kernel(kernel_str);
 			if (STREQ(cpu_str, "*"))
@@ -184,7 +190,7 @@ int main(int argc, char **argv)
 			if (STREQ(wm_theme_str, "*"))
 				detect_wm_theme(wm_theme_str, wm_str);
 			if (STREQ(gtk_str, "*"))
-				detect_gtk(gtk_str);
+				detect_gtk(gtk_str, icon_str, font_str);
 		}
 
 		else /* if the user decided to leave manual mode without input */
@@ -192,9 +198,9 @@ int main(int argc, char **argv)
 	}
 	else /* each string is filled by its respective function */
 	{
-		detect_distro(distro_str);
-		detect_arch(arch_str);
-		detect_host(host_str);
+		detect_distro(distro_str, host_colour);
+		/*detect_arch(arch_str);*/
+		detect_host(host_str, host_colour);
 		detect_kernel(kernel_str);
 		detect_uptime(uptime_str);
 		detect_pkgs(pkgs_str, distro_str);
@@ -207,7 +213,7 @@ int main(int argc, char **argv)
 		detect_de(de_str);
 		detect_wm(wm_str);
 		detect_wm_theme(wm_theme_str, wm_str);
-		detect_gtk(gtk_str);
+		detect_gtk(gtk_str, icon_str, font_str);
 	}
 
 	/* if the user specified a different OS to display, set distro_set to it */

--- a/src/plat/linux/detect.c
+++ b/src/plat/linux/detect.c
@@ -34,12 +34,14 @@
 
 /*	detect_distro
 	detects the computer's distribution (really only relevant on Linux)
-	argument char *str: the char array to be filled with the distro name
+	argument char *str1: the char array to be filled with the distro name
+	argument char *str2: the char array to be filled with the distro colour
+	so we can print "user@hostname" with the same colour as the detected distro one
 */
-void detect_distro(char *str)
+void detect_distro(char *str1, char *str2)
 {
 	/* if distro_str was NOT set by the -D flag or manual mode */
-	if (STREQ(str, "Unknown") || STREQ(str, "*"))
+	if (STREQ(str1, "Unknown") || STREQ(str1, "*"))
 	{
 		FILE *distro_file;
 
@@ -47,7 +49,8 @@ void detect_distro(char *str)
 
 		if (FILE_EXISTS("/system/bin/getprop"))
 		{
-			safe_strncpy(str, "Android", MAX_STRLEN);
+			safe_strncpy(str1, "Android", MAX_STRLEN);
+			sprintf(str2, "%s", TLGN);
 		}
 		else
 		{
@@ -64,29 +67,34 @@ void detect_distro(char *str)
 
 				if (STREQ(distro_name_str, "Kali"))
 				{
-					safe_strncpy(str, "Kali Linux", MAX_STRLEN);
+					safe_strncpy(str1, "Kali Linux", MAX_STRLEN);
 					detected = true;
+					sprintf(str2, "%s", TLBL);
 				}
 				else if (STREQ(distro_name_str, "Back"))
 				{
-					safe_strncpy(str, "Backtrack Linux", MAX_STRLEN);
+					safe_strncpy(str1, "Backtrack Linux", MAX_STRLEN);
 					detected = true;
+					sprintf(str2, "%s", TLRD);
 				}
 				else if (STREQ(distro_name_str, "Crun"))
 				{
-					safe_strncpy(str, "CrunchBang", MAX_STRLEN);
+					safe_strncpy(str1, "CrunchBang", MAX_STRLEN);
 					detected = true;
+					sprintf(str2, "%s", TDGY);
 				}
 				else if (STREQ(distro_name_str, "LMDE"))
 				{
-					safe_strncpy(str, "LMDE", MAX_STRLEN);
+					safe_strncpy(str1, "LMDE", MAX_STRLEN);
 					detected = true;
+					sprintf(str2, "%s", TLGN);
 				}
 				else if (STREQ(distro_name_str, "Debi")
 						|| STREQ(distro_name_str, "Rasp"))
 				{
-					safe_strncpy(str, "Debian", MAX_STRLEN);
+					safe_strncpy(str1, "Debian", MAX_STRLEN);
 					detected = true;
+					sprintf(str2, "%s", TLRD);
 				}
 			}
 
@@ -94,27 +102,33 @@ void detect_distro(char *str)
 			{
 				if (FILE_EXISTS("/etc/fedora-release"))
 				{
-					safe_strncpy(str, "Fedora", MAX_STRLEN);
+					safe_strncpy(str1, "Fedora", MAX_STRLEN);
+					sprintf(str2, "%s", TLBL);
 				}
 				else if (FILE_EXISTS("/etc/SuSE-release"))
 				{
-					safe_strncpy(str, "OpenSUSE", MAX_STRLEN);
+					safe_strncpy(str1, "OpenSUSE", MAX_STRLEN);
+					sprintf(str2, "%s", TLGN);
 				}
 				else if (FILE_EXISTS("/etc/arch-release"))
 				{
-					safe_strncpy(str, "Arch Linux", MAX_STRLEN);
+					safe_strncpy(str1, "Arch Linux", MAX_STRLEN);
+					sprintf(str2, "%s", TLCY);
 				}
 				else if (FILE_EXISTS("/etc/gentoo-release"))
 				{
-					safe_strncpy(str, "Gentoo", MAX_STRLEN);
+					safe_strncpy(str1, "Gentoo", MAX_STRLEN);
+					sprintf(str2, "%s", TLPR);
 				}
 				else if (FILE_EXISTS("/etc/angstrom-version"))
 				{
-					safe_strncpy(str, "Angstrom", MAX_STRLEN);
+					safe_strncpy(str1, "Angstrom", MAX_STRLEN);
+					sprintf(str2, "%s", TNRM);
 				}
 				else if (FILE_EXISTS("/etc/manjaro-release"))
 				{
-					safe_strncpy(str, "Manjaro", MAX_STRLEN);
+					safe_strncpy(str1, "Manjaro", MAX_STRLEN);
+					sprintf(str2, "%s", TLGN);
 				}
 				else if (FILE_EXISTS("/etc/lsb-release"))
 				{
@@ -122,7 +136,8 @@ void detect_distro(char *str)
 					fscanf(distro_file, "%s ", distro_name_str);
 					fclose(distro_file);
 
-					snprintf(str, MAX_STRLEN, "%s", distro_name_str + 11);
+					snprintf(str1, MAX_STRLEN, "%s", distro_name_str + 11);
+					sprintf(str2, "%s", TLRD);
 				}
 				else if (FILE_EXISTS("/etc/os-release"))
 				{
@@ -135,7 +150,8 @@ void detect_distro(char *str)
 				}
 				else
 				{
-					safe_strncpy(str, "Linux", MAX_STRLEN);
+					safe_strncpy(str1, "Linux", MAX_STRLEN);
+					sprintf(str2, "%s", TLGY);
 
 					if (error)
 					{
@@ -153,20 +169,21 @@ void detect_distro(char *str)
 	detects the computer's architecture
 	argument char *str: the char array to be filled with the architecture
 */
-void detect_arch(char *str)
+/*void detect_arch(char *str)
 {
 	struct utsname arch_info;
 	uname(&arch_info);
 	safe_strncpy(str, arch_info.machine, MAX_STRLEN);
 
 	return;
-}
+}*/
 
 /*	detect_host
 	detects the computer's hostname and active user and formats them
-	argument char *str: the char array to be filled with the host info
+	argument char *str1: the char array to be filled with the host info
+	argument char *str2: the passed distro colour for "user@hostname"
 */
-void detect_host(char *str)
+void detect_host(char *str1, char *str2)
 {
 	char given_user[MAX_STRLEN] = "Unknown";
 	char given_host[MAX_STRLEN] = "Unknown";
@@ -191,7 +208,8 @@ void detect_host(char *str)
 		ERR_REPORT("Could not detect hostname.");
 	}
 
-	snprintf(str, MAX_STRLEN, "%s@%s", given_user, given_host);
+	snprintf(str1, MAX_STRLEN, "%s%s%s%s@%s%s%s%s",
+		str2, given_user, TNRM, TWHT, TNRM, str2, given_host, TNRM);
 
 	return;
 }
@@ -206,7 +224,7 @@ void detect_kernel(char *str)
 
 	if (!(uname(&kern_info)))
 	{
-		snprintf(str, MAX_STRLEN, "%s %s", kern_info.sysname, kern_info.release);
+		snprintf(str, MAX_STRLEN, "%s %s %s", kern_info.sysname, kern_info.release, kern_info.machine);
 	}
 	else if (error)
 	{
@@ -714,13 +732,15 @@ void detect_wm_theme(char *str, const char *wm_str)
 
 /*	detect_gtk
 	detects the theme, icon(s), and font(s) associated with a GTK DE (if present)
-	argument char *str: the char array to be filled with the GTK info
+	argument char *str1: the char array to be filled with the GTK info
+	argument char *str2: the char array to be filled with GTK icons
+	argument char *str3: the char array to be filled with Font
 	--
 	CAVEAT: This function relies on the presence of 'detectgtk', a shell script.
 	If it isn't present somewhere in the PATH, the GTK will be set as 'Unknown'
 	--
 */
-void detect_gtk(char *str)
+void detect_gtk(char *str1, char *str2, char *str3)
 {
 	FILE *gtk_file;
 	char gtk2_str[MAX_STRLEN] = "Unknown";
@@ -733,13 +753,17 @@ void detect_gtk(char *str)
 	pclose(gtk_file);
 
 	if (STREQ(gtk3_str, "Unknown"))
-		snprintf(str, MAX_STRLEN, "%s (GTK2), %s (Icons)", gtk2_str,
+		snprintf(str1, MAX_STRLEN, "%s (GTK2), %s (Icons)", gtk2_str,
 				gtk_icons_str);
 	else if (STREQ(gtk2_str, "Unknown"))
-		snprintf(str, MAX_STRLEN, "%s (GTK3), %s (Icons)", gtk3_str,
+		snprintf(str1, MAX_STRLEN, "%s (GTK3), %s (Icons)", gtk3_str,
 				gtk_icons_str);
 	else
-		snprintf(str, MAX_STRLEN, "%s (GTK2), %s (GTK3)", gtk2_str, gtk3_str);
+		snprintf(str1, MAX_STRLEN, "%s (GTK2), %s (GTK3)", gtk2_str, gtk3_str);
+
+	snprintf(str2, MAX_STRLEN, "%s", gtk_icons_str);
+
+	snprintf(str3, MAX_STRLEN, "%s", font_str);
 
 	return;
 }

--- a/src/scripts/detectgpu
+++ b/src/scripts/detectgpu
@@ -6,9 +6,19 @@
 #  Modified to stand alone by William Woodruff (woodruffw) in screenfetch-c
 
 if [ -n "$(type -p lspci)" ]; then
-	gpu_info=$(lspci 2> /dev/null | grep VGA)
-	gpu=$(echo "$gpu_info" | grep -oE '\[.*\]' | sed 's/\[//;s/\]//')
-	gpu=$(echo "${gpu}" | sed -n '1h;2,$H;${g;s/\n/, /g;p}')
+	# gpu_info=$(lspci 2> /dev/null | grep VGA)
+	# gpu=$(echo "$gpu_info" | grep -oE '\[.*\]' | sed 's/\[//;s/\]//')
+	# gpu=$(echo "${gpu}" | sed -n '1h;2,$H;${g;s/\n/, /g;p}')
+
+	# better gpu detection with g/awk than sed
+	# sed requires '[manufactor] dummy info [model name]'
+	# here 'manufactor' and 'model name' have to be in '[]',
+	# otherwise the output will be awkward. g/awk seperates
+	# the output from the first '[' onwards. Try to parse this with sed and g/awk:
+	# 01:05.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] RS780L Radeon 3000
+
+	gpu=$(lspci | awk -F '[' '/VGA/ {gsub("]","");OFS="";print $2,$3}')
+
 elif [[ -n "$(type -p glxinfo)" && -z "$gpu" ]]; then
 	gpu_info=$(glxinfo 2>/dev/null)
 	gpu=$(echo "$gpu_info" | grep "OpenGL renderer string")
@@ -35,4 +45,4 @@ else
 	gpu="Unknown"
 fi
 
-printf $gpu
+echo ${gpu}

--- a/src/scripts/detectgtk
+++ b/src/scripts/detectgtk
@@ -11,7 +11,15 @@ gtk3Theme="Unknown"
 gtkIcons="Unknown"
 gtkFont="Unknown"
 
-DE=`detectde`
+# Where is `detectde' located ?
+# Until then it will be comment in
+
+#DE=`detectde`
+DE="Unknown"
+
+home_gtkrc_two="$HOME/.gtkrc-2.0"
+usr_gtkrc_two='/usr/share/gtk-2.0/gtkrc'
+home_gtkrc_mine="$HOME/.gtkrc.mine"
 
 case $DE in
 	'KDE'*) # Desktop Environment found as "KDE"
@@ -39,27 +47,27 @@ case $DE in
 		fi
 		if [[ -n ${KDE_CONFIG_FILE} ]]; then
 			if grep -q "widgetStyle=" "${KDE_CONFIG_FILE}"; then
-				gtk2Theme=$(awk -F"=" '/widgetStyle=/ {print $2}' "${KDE_CONFIG_FILE}")
+				gtk2Theme=$(awk -F "=" '/widgetStyle=/ {print $2}' "${KDE_CONFIG_FILE}")
 			elif grep -q "colorScheme=" "${KDE_CONFIG_FILE}"; then
-				gtk2Theme=$(awk -F"=" '/colorScheme=/ {print $2}' "${KDE_CONFIG_FILE}")
+				gtk2Theme=$(awk -F "=" '/colorScheme=/ {print $2}' "${KDE_CONFIG_FILE}")
 			fi
 			if grep -q "Theme=" "${KDE_CONFIG_FILE}"; then
-				gtkIcons=$(awk -F"=" '/Theme=/ {print $2}' "${KDE_CONFIG_FILE}")
+				gtkIcons=$(awk -F "=" '/Theme=/ {print $2}' "${KDE_CONFIG_FILE}")
 			fi
 			if grep -q "Font=" "${KDE_CONFIG_FILE}"; then
-				gtkFont=$(awk -F"=" '/font=/ {print $2}' "${KDE_CONFIG_FILE}")
+				gtkFont=$(awk -F "=" '/font=/ {print $2}' "${KDE_CONFIG_FILE}")
 			fi
 		fi
-		if [[ -f $HOME/.gtkrc-2.0 ]]; then
-			gtk2Theme=$(grep '^gtk-theme-name' $HOME/.gtkrc-2.0 | awk -F'=' '{print $2}')
+		if [[ -f ${home_gtkrc_two} ]]; then
+			gtk2Theme=$(grep '^gtk-theme-name' ${home_gtkrc_two} | awk -F '=' '{print $2}')
 			gtk2Theme=${gtk2Theme//\"/}
-			gtkIcons=$(grep '^gtk-icon-theme-name' $HOME/.gtkrc-2.0 | awk -F'=' '{print $2}')
+			gtkIcons=$(grep '^gtk-icon-theme-name' ${home_gtkrc_two} | awk -F '=' '{print $2}')
 			gtkIcons=${gtkIcons//\"/}
-			gtkFont=$(grep 'font_name' $HOME/.gtkrc-2.0 | awk -F'=' '{print $2}')
+			gtkFont=$(grep 'font_name' ${home_gtkrc_two} | awk -F '=' '{print $2}')
 			gtkFont=${gtkFont//\"/}
 		fi
 		if [[ -f $HOME/.config/gtk-3.0/settings.ini ]]; then
-			gtk3Theme=$(grep '^gtk-theme-name=' $HOME/.config/gtk-3.0/settings.ini | awk -F'=' '{print $2}')
+			gtk3Theme=$(grep '^gtk-theme-name=' $HOME/.config/gtk-3.0/settings.ini | awk -F '=' '{print $2}')
 		fi
 	;;
 	'Cinnamon'*) # Desktop Environment found as "Cinnamon"
@@ -90,7 +98,7 @@ case $DE in
 			gtkFont=$(gconftool-2 -g /desktop/gnome/interface/font_name)
 			if [ "$background_detect" == "1" ]; then
 				gtkBackgroundFull=$(gconftool-2 -g /desktop/gnome/background/picture_filename)
-				gtkBackground=$(echo "$gtkBackgroundFull" | awk -F"/" '{print $NF}')
+				gtkBackground=$(echo "$gtkBackgroundFull" | awk -F "/" '{print $NF}')
 			fi
 		fi
 	;;
@@ -128,72 +136,87 @@ case $DE in
 		fi
 		# TODO: Clean me.
 		if grep -q "sNet\/ThemeName" ${XDG_CONFIG_HOME:-${HOME}/.config}$lxdeconf 2>/dev/null; then
-			gtk2Theme=$(awk -F'=' '/sNet\/ThemeName/ {print $2}' ${XDG_CONFIG_HOME:-${HOME}/.config}$lxdeconf)
+			gtk2Theme=$(awk -F '=' '/sNet\/ThemeName/ {print $2}' ${XDG_CONFIG_HOME:-${HOME}/.config}$lxdeconf)
 		fi
 		if grep -q IconThemeName ${XDG_CONFIG_HOME:-${HOME}/.config}$lxdeconf 2>/dev/null; then
-			gtkIcons=$(awk -F'=' '/sNet\/IconThemeName/ {print $2}' ${XDG_CONFIG_HOME:-${HOME}/.config}$lxdeconf)
+			gtkIcons=$(awk -F '=' '/sNet\/IconThemeName/ {print $2}' ${XDG_CONFIG_HOME:-${HOME}/.config}$lxdeconf)
 		fi
 		if grep -q FontName ${XDG_CONFIG_HOME:-${HOME}/.config}$lxdeconf 2>/dev/null; then
-			gtkFont=$(awk -F'=' '/sGtk\/FontName/ {print $2}' ${XDG_CONFIG_HOME:-${HOME}/.config}$lxdeconf)
+			gtkFont=$(awk -F '=' '/sGtk\/FontName/ {print $2}' ${XDG_CONFIG_HOME:-${HOME}/.config}$lxdeconf)
 		fi
 	;;
 	# /home/me/.config/rox.sourceforge.net/ROX-Session/Settings.xml
 	*)	# Lightweight or No DE Found
-		if [ -f $HOME/.gtkrc-2.0 ]; then
-			if grep -q gtk-theme $HOME/.gtkrc-2.0; then
-				gtk2Theme=$(awk -F'"' '/^gtk-theme/ {print $2}' $HOME/.gtkrc-2.0)
+		if [ -f ${home_gtkrc_two} ]; then
+			if grep -q gtk-theme ${home_gtkrc_two}; then
+				gtk2Theme=$(awk -F '"' '/^gtk-theme/ {print $2}' ${home_gtkrc_two})
 			fi
-			if grep -q icon-theme $HOME/.gtkrc-2.0; then
-				gtkIcons=$(awk -F'"' '/^gtk-icon-theme/ {print $2}' $HOME/.gtkrc-2.0)
+			if grep -q icon-theme ${home_gtkrc_two}; then
+				gtkIcons=$(awk -F '"' '/^gtk-icon-theme/ {print $2}' ${home_gtkrc_two})
 			fi
-			if grep -q font $HOME/.gtkrc-2.0; then
-				gtkFont=$(awk -F'"' '/^gtk-font-name/ {print $2}' $HOME/.gtkrc-2.0)
+			if grep -q font ${home_gtkrc_two}; then
+				gtkFont=$(awk -F '"' '/^gtk-font-name/ {print $2}' ${home_gtkrc_two})
 			fi
 		fi
 		# $HOME/.gtkrc.mine theme detect only
-		if [ -f $HOME/.gtkrc.mine ]; then
-			if grep -q "^include" $HOME/.gtkrc.mine; then
-				gtk2Theme=$(grep '^include.*gtkrc' $HOME/.gtkrc.mine | awk -F "/" '{ print $5 }')
+		if [[ -f ${home_gtkrc_mine} && ! -f ${home_gtkrc_two} ]]; then
+			if grep -q "^include" ${home_gtkrc_mine}; then
+				gtk2Theme=$(grep '^include.*gtkrc' ${home_gtkrc_mine} | awk -F "/" '{ print $5 }')
 			fi
-			if grep -q "^gtk-icon-theme-name" $HOME/.gtkrc.mine; then
-				gtkIcons=$(grep '^gtk-icon-theme-name' $HOME/.gtkrc.mine | awk -F '"' '{print $2}')
+			if grep -q "^gtk-icon-theme-name" ${home_gtkrc_mine}; then
+				gtkIcons=$(grep '^gtk-icon-theme-name' ${home_gtkrc_mine} | awk -F '"' '{print $2}')
+			fi
+		fi
+		# /usr/share/gtk-2.0/gtkrc
+		if [[ -f ${usr_gtkrc_two} && ! -f ${home_gtkrc_mine} && ! -f ${home_gtkrc_two} ]]; then
+			if grep -q gtk-theme ${usr_gtkrc_two}; then
+				gtk2Theme=$(awk -F '"' '/^gtk-theme/ {print $2}' ${usr_gtkrc_two})
+			fi
+			if grep -q icon-theme ${usr_gtkrc_two}; then
+				gtkIcons=$(awk -F '"' '/^gtk-icon-theme/ {print $2}' ${usr_gtkrc_two})
+			fi
+			if grep -q font ${usr_gtkrc_two}; then
+				gtkFont=$(awk -F '"' '/^gtk-font-name/ {print $2}' ${usr_gtkrc_two})
 			fi
 		fi
 		# /etc/gtk-2.0/gtkrc compatability
-		if [[ -f /etc/gtk-2.0/gtkrc && ! -f $HOME/.gtkrc-2.0 && ! -f $HOME/.gtkrc.mine ]]; then
-			if grep -q gtk-theme-name /etc/gtk-2.0/gtkrc; then
-				gtk2Theme=$(awk -F'"' '/^gtk-theme-name/ {print $2}' /etc/gtk-2.0/gtkrc)
+		etc_gtkrc_two='/etc/gtk-2.0/gtkrc'
+		if [[ -f ${etc_gtkrc_two} && ! -f ${home_gtkrc_two} && ! -f ${home_gtkrc_mine} && ! -f ${usr_gtkrc_two} ]]; then
+			if grep -q gtk-theme-name ${etc_gtkrc_two}; then
+				gtk2Theme=$(awk -F '"' '/^gtk-theme-name/ {print $2}' ${etc_gtkrc_two})
 			fi
-			if grep -q gtk-fallback-theme-name /etc/gtk-2.0/gtkrc  && ! [ "x$gtk2Theme" = "x" ]; then
-				gtk2Theme=$(awk -F'"' '/^gtk-fallback-theme-name/ {print $2}' /etc/gtk-2.0/gtkrc)
+			if grep -q gtk-fallback-theme-name ${etc_gtkrc_two}  && ! [ "x$gtk2Theme" = "x" ]; then
+				gtk2Theme=$(awk -F '"' '/^gtk-fallback-theme-name/ {print $2}' ${etc_gtkrc_two})
 			fi
-			if grep -q icon-theme /etc/gtk-2.0/gtkrc; then
-				gtkIcons=$(awk -F'"' '/^icon-theme/ {print $2}' /etc/gtk-2.0/gtkrc)
+			if grep -q icon-theme ${etc_gtkrc_two}; then
+				gtkIcons=$(awk -F '"' '/^icon-theme/ {print $2}' ${etc_gtkrc_two})
 			fi
-			if  grep -q gtk-fallback-icon-theme /etc/gtk-2.0/gtkrc  && ! [ "x$gtkIcons" = "x" ]; then
-				gtkIcons=$(awk -F'"' '/^gtk-fallback-icon-theme/ {print $2}' /etc/gtk-2.0/gtkrc)
+			if  grep -q gtk-fallback-icon-theme ${etc_gtkrc_two}  && ! [ "x$gtkIcons" = "x" ]; then
+				gtkIcons=$(awk -F '"' '/^gtk-fallback-icon-theme/ {print $2}' ${etc_gtkrc_two})
 			fi
-			if grep -q font /etc/gtk-2.0/gtkrc; then
-				gtkFont=$(awk -F'"' '/^gtk-font-name/ {print $2}' /etc/gtk-2.0/gtkrc)
+			if grep -q font ${etc_gtkrc_two}; then
+				gtkFont=$(awk -F '"' '/^gtk-font-name/ {print $2}' ${etc_gtkrc_two})
 			fi
 		fi
 		# EXPERIMENTAL gtk3 Theme detection
-		if [ -f $HOME/.config/gtk-3.0/settings.ini ]; then
-			if grep -q gtk-theme-name $HOME/.config/gtk-3.0/settings.ini; then
-				gtk3Theme=$(awk -F'=' '/^gtk-theme-name/ {print $2}' $HOME/.config/gtk-3.0/settings.ini)
+		home_conf_gtk_three="$HOME/.config/gtk-3.0/settings.ini"
+		if [ -f ${home_conf_gtk_three} ]; then
+			if grep -q gtk-theme-name ${home_conf_gtk_three}; then
+				gtk3Theme=$(awk -F '=' '/^gtk-theme-name/ {print $2}' ${home_conf_gtk_three})
 			fi
 		fi
 		# Proper gtk3 Theme detection
 		#if [ $(which gsettings) ] && [ "$distro" != "Mac OS X" ]; then
 		#	gtk3Theme="$(gsettings get org.gnome.desktop.interface gtk-theme | tr -d \"\'\")"
 		#fi
-		if type -p gsettings >/dev/null 2>&1; then
-			gtk3Theme=$(gsettings get org.gnome.desktop.interface gtk-theme 2>/dev/null)
-			gtk3Theme=${gtk3Theme//"'"}
-		fi
+		# gsettings and xfconf-query should only be used in their desktop environments
+		#if type -p gsettings >/dev/null 2>&1; then
+		#	gtk3Theme=$(gsettings get org.gnome.desktop.interface gtk-theme 2>/dev/null)
+		#	gtk3Theme=${gtk3Theme//"'"}
+		#fi
 		# ROX-Filer icon detect only
 		if [ -a ${XDG_CONFIG_HOME:-${HOME}/.config}/rox.sourceforge.net/ROX-Filer/Options ]; then
-			gtkIcons=$(awk -F'[>,<]' '/^icon_theme/ {print $3}' ${XDG_CONFIG_HOME:-${HOME}/.config}/rox.sourceforge.net/ROX-Filer/Options)
+			gtkIcons=$(awk -F '[>,<]' '/^icon_theme/ {print $3}' ${XDG_CONFIG_HOME:-${HOME}/.config}/rox.sourceforge.net/ROX-Filer/Options)
 		fi
 		# E17 detection
 		if [ $E_ICON_THEME ]; then
@@ -204,10 +227,10 @@ case $DE in
 		# Background Detection (feh, nitrogen)
 		if [ "$background_detect" == "1" ]; then
 			if [ -a $HOME/.fehbg ]; then
-				gtkBackgroundFull=$(awk -F"'" '/feh --bg/{print $2}' $HOME/.fehbg 2>/dev/null)
-				gtkBackground=$(echo "$gtkBackgroundFull" | awk -F"/" '{print $NF}')
+				gtkBackgroundFull=$(awk -F "'" '/feh --bg/{print $2}' $HOME/.fehbg 2>/dev/null)
+				gtkBackground=$(echo "$gtkBackgroundFull" | awk -F "/" '{print $NF}')
 			elif [ -a ${XDG_CONFIG_HOME:-${HOME}/.config}/nitrogen/bg-saved.cfg ]; then
-				gtkBackground=$(awk -F"/" '/file=/ {print $NF}' ${XDG_CONFIG_HOME:-${HOME}/.config}/nitrogen/bg-saved.cfg)
+				gtkBackground=$(awk -F "/" '/file=/ {print $NF}' ${XDG_CONFIG_HOME:-${HOME}/.config}/nitrogen/bg-saved.cfg)
 			fi
 		fi
 	;;


### PR DESCRIPTION
Hello William,

Decided to help you out with screenfetch-c, will list the changes here because
I was working on 3 weeks old copy of your program.

Two pictures will be attached by the time you read this, so you can preview
what I've done without reading the described changes below the pics:

![to_send](https://cloud.githubusercontent.com/assets/4725121/5855680/d88fd048-a232-11e4-88c6-732842f53ad1.png)

![to_send](https://cloud.githubusercontent.com/assets/4725121/5855687/ea58fea8-a232-11e4-82fd-cc6de055b821.png)
![to_send2](https://cloud.githubusercontent.com/assets/4725121/5855740/72416684-a233-11e4-879c-52bba8e3eaf5.png)


colors.h - the non-bold colours was fixed by adding 0; , that is why the
archlogo wasn't able to show darker colour where the manifest constants
was substitued.

detect.h - comment in detect_arch function prototype, because it will be moved
to the "Kernel", detect_distro function prototype now takes two formal
parameters, the second parameter/argument will be used so we can print the
"user@hostname" with the same colour as the detected distro one. detect_host
takes two formal parameters/arguments (explained earlier what it will do with "user@hostname").
detect_gtk function prototype now takes 3 formal parameters/arguments, so we
can print "Icon Theme" and "Font" which are detected by the detectgtk bash
script.

Fixed the detectgtk script, because it was overriding the detected gtk themes
and icon theme, added proper testing and new location to look for gtkrc,
few variables was declared so we can make our life easier instead typing same
strings over and over again.

Fixed detectgpu script, wrote proper gpu detection with g/awk and deprecated
the sed one.

disp.h - Added two function prototypes so we can eliminate some of the
repeating code in disp.c

disp.c - In main_ascii_output function changed the for loop condition values
regarding "Arch Linux", so the loop can iterate one more time and show the
whole logo instead truncating the last part of it (the very bottom).
Removed all 'for' loops in output_logo_only and main_ascii_output functions body,
so now they do function calls to process_data and process_logo_only, thus
following the "Don't Repeat Yourself" principle.

main.c - comment in the 'arch_str' chararacter array, added icon_str and
font_str char arrays, later one host_colour char array was added so it will
hold the printable "user@hostname" colour. Removed arch_str and
added icon_str and font_str in detected_arr. Removed "Arch: " and added "Icon
theme: ", "Font: " in detected_arr_name. The functions that takes more arguments
was edited (see the changes in detect.h)

detect.c - same description as detect.h but instead function prototypes the
function headers was edited and their body to match the actions described in
detect.h

There is a lot work to be done, as I edited only the plat/linux/detect.c module.

It would be great if you could replace getopt.h with argp.h, also if you
could add internationalization support with gettext and *.po files it will be
neat feature because everything will be shown in native system language instead
English, there is no way to predict what the "detected" text will be as user
hardware varies, so it shouldn't be translated.

Could you switch to cmake or autoconf/autotools (gnu build system) instead
standalone and predefined Makefile ?

Any changes that are not described here are probably overwritten by my old
screenfetch-c copy.

Best regards,
Aaron Caffrey