### PR TITLE
fix OSX 10.10 build

### DIFF
--- a/src/arrays.h
+++ b/src/arrays.h
@@ -13,6 +13,8 @@
 
 extern char given_distro_str[MAX_STRLEN];
 extern char distro_str[MAX_STRLEN];
+extern char distro_name_distro_str[MAX_STRLEN];
+extern char distro_name_str[MAX_STRLEN];
 extern char host_str[MAX_STRLEN];
 extern char kernel_str[MAX_STRLEN];
 extern char uptime_str[MAX_STRLEN];

--- a/src/plat/darwin/detect.c
+++ b/src/plat/darwin/detect.c
@@ -35,6 +35,9 @@
 #include "../../util.h"
 #include "../../error_flag.h"
 
+char distro_name_distro_str[MAX_STRLEN];
+char distro_name_str[MAX_STRLEN];
+
 /*	detect_distro
 	detects the computer's distribution (OS X release)
 */


### PR DESCRIPTION
I'm pretty sure this isn't the correct style for this project, but it is a PoC of the fix required. It might be preferable to make `distro_name_distro_str` and `distro_name_str` local variables in `detect_distro`.

Do note that there are still errors that happen when the application is called.

```
sh: sysctl: command not found
sh: system_profiler: not found
sh: sysctl: command not found
sh: system_profiler: not found
```

This does, however, build and output mostly correct data. It is unable to detect the CPU or GPU or memory resolution. I'll look into this soon.

Full output located at https://gist.github.com/skyhighwings/112402e2c96712af9cbf

Tested on OSX 10.10 on my mid-2015 MBP.