### PR TITLE
Support MinGW compiler target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ TESTS =
 
 OLDTARGETS = linux win bsd osx sun
 
+ifeq ($(COLORS),0)
+	CPPFLAGS += -DNO_COLORS
+endif
 ifeq ($(OS),Windows_NT)
 	SOURCES += $(wildcard ./src/plat/win32/*.c)
 	CPPFLAGS += -DWIN32_LEAN_AND_MEAN

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ $ cd screenfetch-c
 $ make
 ```
 
+If you want to disable colors you can run `make COLORS=0` instead.
+
 _Note:_ For Solaris, `make` *must* be GNU make. If it isn't, use `gmake`. Using regular (Sun) `make` will cause strange errors.
 
 ### OS X
@@ -73,7 +75,7 @@ In particular, the following things still need to be done:
 _Note:_ These are only the ones that have actually been tested (so far). screenfetch-c may very well work on many of the untested distros, so feel free to try it.
 
 - [x] OS X
-- [x] Windows (requires Cygwin)
+- [x] Windows (Cygwin, MSYS2, MinGW)
 - [x] Arch Linux
 - [x] Fedora
 - [x] Linux Mint

--- a/src/arrays.c
+++ b/src/arrays.c
@@ -7,6 +7,7 @@
 */
 
 
+#include "arrays.h"
 #include "misc.h"
 #include "colors.h"
 
@@ -31,7 +32,7 @@ char font_str[MAX_STRLEN] = "Unknown";
 
 char host_color[MAX_STRLEN] = TNRM;
 
-char *detected_arr[17] =
+char *detected_arr[DETECTED_ARR_LEN] =
 {
 	host_str,
 	distro_str,
@@ -52,7 +53,7 @@ char *detected_arr[17] =
 	font_str
 };
 
-char *detected_arr_names[17] =
+char *detected_arr_names[DETECTED_ARR_LEN] =
 {
 	"",
 	"OS: ",

--- a/src/arrays.h
+++ b/src/arrays.h
@@ -30,9 +30,10 @@ extern char gtk_str[MAX_STRLEN];
 extern char icon_str[MAX_STRLEN];
 extern char font_str[MAX_STRLEN];
 
-extern char host_color[10];
+extern char host_color[MAX_STRLEN];
 
-extern char *detected_arr[17];
-extern char *detected_arr_names[17];
+#define DETECTED_ARR_LEN 17
+extern char *detected_arr[DETECTED_ARR_LEN];
+extern char *detected_arr_names[DETECTED_ARR_LEN];
 
 #endif /* SCREENFETCH_C_ARRAYS_H */

--- a/src/colors.h
+++ b/src/colors.h
@@ -9,6 +9,28 @@
 #ifndef SCREENFETCH_C_COLORS_H
 #define SCREENFETCH_C_COLORS_H
 
+#ifdef NO_COLORS
+
+#define TNRM ""
+#define TBLK ""
+#define TRED ""
+#define TGRN ""
+#define TBRN ""
+#define TBLU ""
+#define TPUR ""
+#define TCYN ""
+#define TLGY ""
+#define TDGY ""
+#define TLRD ""
+#define TLGN ""
+#define TYLW ""
+#define TLBL ""
+#define TLPR ""
+#define TLCY ""
+#define TWHT ""
+
+#else
+
 #define TNRM "\x1B[0m" /* normal */
 #define TBLK "\x1B[0;30m" /* black */
 #define TRED "\x1B[0;31m" /* red */
@@ -26,5 +48,7 @@
 #define TLPR "\x1B[1;35m" /* light purple */
 #define TLCY "\x1B[1;36m" /* light cyan */
 #define TWHT "\x1B[1;37m" /* white */
+
+#endif
 
 #endif

--- a/src/disp.c
+++ b/src/disp.c
@@ -18,6 +18,7 @@
 #include "colors.h"
 #include "misc.h"
 #include "disp.h"
+#include "arrays.h"
 
 /*	display_version
 	called if the -V (--version) flag is tripped
@@ -58,7 +59,7 @@ void display_help(void)
 void display_verbose(char *data[], char *data_names[])
 {
 	int i = 0;
-	for (i = 0; i < 16; i++)
+	for (i = 0; i < DETECTED_ARR_LEN; i++)
 		VERBOSE_OUT(data_names[i], data[i]);
 
 	return;
@@ -472,7 +473,7 @@ void main_text_output(char *data[], char *data_names[])
 {
 	int i;
 
-	for (i = 0; i < 16; i++)
+	for (i = 0; i < DETECTED_ARR_LEN; i++)
 		printf("%s %s\n", data_names[i], data[i]);
 
 	return;

--- a/src/util.c
+++ b/src/util.c
@@ -18,7 +18,7 @@
 #include "misc.h"
 #include "error_flag.h"
 
-#if defined(__CYGWIN__) || defined(__MSYS__)
+#if defined(__CYGWIN__) || defined(__MSYS__) || defined(__MINGW32__)
 	#include <Windows.h>
 	#include "plat/win32/bitmap.h"
 #endif
@@ -58,7 +58,7 @@ void split_uptime(long uptime, unsigned int *secs, unsigned int *mins,
 */
 void take_screenshot(bool verbose)
 {
-#if !defined(__CYGWIN__) && !defined(__MSYS__)
+#if !defined(__CYGWIN__) && !defined(__MSYS__) && !defined(__MINGW32__)
 	int call_status = 1;
 	char file_loc[MAX_STRLEN];
 #endif
@@ -74,7 +74,7 @@ void take_screenshot(bool verbose)
 	sleep(1);
 	printf("%s\n", "0");
 
-#if defined(__CYGWIN__) || defined(__MSYS__)
+#if defined(__CYGWIN__) || defined(__MSYS__) || defined(__MINGW32__)
 	HDC screen_dc = GetDC(NULL);
 	HDC mem_dc = CreateCompatibleDC(screen_dc);
 
@@ -105,7 +105,7 @@ void take_screenshot(bool verbose)
 		call_status = system("scrot ~/screenfetch_screenshot.png 2> /dev/null");
 #endif
 
-#if !defined(__CYGWIN__) && !defined(__MSYS__)
+#if !defined(__CYGWIN__) && !defined(__MSYS__) && !defined(__MINGW32__)
 	safe_strncpy(file_loc, getenv("HOME"), MAX_STRLEN);
 	strncat(file_loc, "/screenfetch_screenshot.png", MAX_STRLEN);
 


### PR DESCRIPTION
![sf-mingw](https://cloud.githubusercontent.com/assets/5700937/18348311/e9a4d924-75ca-11e6-8efc-426155846773.png)

Top left: command prompt with colors, using [ansicon](https://github.com/adoxa/ansicon) and the following batch script:
``` batch
@echo off
set SHELL=cmd.exe
echo.
cmd /C ansicon.exe screenfetch-c.exe
echo.
pause
```

Bottom left: same as top left, but without ansicon and screenfetch-c being compiled with `make COLORS=0`

Top right: Windows PowerShell, which supports colors by default, using this script:
``` ps1
$env:SHELL = "PowerShell"
Write-Host ""
Invoke-Expression -Command:"cmd /C screenfetch-c.exe"
Write-Host "
Press any key to continue ..."
$x = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")
```

Bottom right: running directly in Cygwin.

cmd.exe and PowerShell don't define `SHELL` and I couldn't find any other way to detect either one so instead I define `SHELL` in the start-up scripts.